### PR TITLE
Update link to Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ discosrv
 ========
 
 This is the global discovery server for the `syncthing` project. To get it, download the
-[latest build](http://build.syncthing.net/job/discosrv/lastSuccessfulBuild/artifact/)
+[latest build](https://build.syncthing.net/job/stdiscosrv/lastSuccessfulBuild/artifact/)
 from the build server. Occasionally, releases will be made available on
 the "Releases" tab of this repository.
 


### PR DESCRIPTION
The job name was changed to stdicsosrv from discosrv and so the link was broken.